### PR TITLE
add REFERENCE_TABLES to schema

### DIFF
--- a/schema/schema_template.py
+++ b/schema/schema_template.py
@@ -28,6 +28,15 @@ from astrodbkit2.astrodb import Base
 # -------------------------------------------------------------------------------------------------------------------
 # Reference tables
 # -------------------------------------------------------------------------------------------------------------------
+REFERENCE_TABLES = [
+    "Publications",
+    "Telescopes",
+    "Instruments",
+    "PhotometryFilters",
+    "Versions",
+]
+
+
 class Publications(Base):
     """ORM for publications table.
     This stores reference information (DOI, bibcodes, etc) and


### PR DESCRIPTION
Declare the REFERENCE_TABLES in the schema.py module so they are imported at the same time as the schema.  Closes #21 
