### PR TITLE
Keep parallax error sig figs >= parallax sig figs

### DIFF
--- a/schema/schema_template.py
+++ b/schema/schema_template.py
@@ -46,6 +46,8 @@ def count_significant_digits_numpy(number):
 
     # Count significant digits
     significant_digits = len(integer_part.lstrip('0')) + len(fractional_part)
+
+    return significant_digits
     
 
 # -------------------------------------------------------------------------------------------------------------------

--- a/schema/schema_template.py
+++ b/schema/schema_template.py
@@ -26,6 +26,26 @@ def check_string_length(value, max_length, key):
         raise ValueError(f"Provided {key} is invalid; too long or None: {value}")
     else:
         pass
+
+def count_significant_digits_numpy(number):
+    # Convert to string with numpy and handle scientific notation
+    num_str = np.format_float_positional(number, precision=15, unique=False, fractional=False, trim='k')
+
+    # Remove leading zeros and the decimal point
+    if '.' in num_str:
+        num_str = num_str.rstrip('0').rstrip('.')
+
+    # Remove leading minus if the number is negative
+    num_str = num_str.lstrip('-')
+
+    # Split into integer and fractional parts
+    if '.' in num_str:
+        integer_part, fractional_part = num_str.split('.')
+    else:
+        integer_part, fractional_part = num_str, ''
+
+    # Count significant digits
+    significant_digits = len(integer_part.lstrip('0')) + len(fractional_part)
     
 
 # -------------------------------------------------------------------------------------------------------------------
@@ -368,6 +388,18 @@ class Parallax(Base):
     @validates("comment")
     def validate_comment_length(self, key, value):
         check_string_length(value, 1000, key)
+        return value
+
+    @validates("parallax_mas")
+    def validate_parallax_sig_figs(self, key, value):
+        if hasattr(self, 'parallax_error'):
+            n_sig_figs_error = count_significant_digits_numpy(self.parallax_error)
+            n_sig_figs_value = count_significant_digits_numpy(value)
+
+            if n_sig_figs_value > n_sig_figs_error:
+                raise ValueError(f"Provided {key} is invalid; more significant figures than value: {value}")
+            else:
+                pass
         return value
 
 # class Measurement(Base):

--- a/schema/schema_template.py
+++ b/schema/schema_template.py
@@ -15,6 +15,7 @@ from astrodbkit2.astrodb import Base
 from sqlalchemy import Column, DateTime, Float, ForeignKey, Integer, String, Boolean
 from sqlalchemy.orm import validates
 from astropy.io.votable.ucd import check_ucd
+import numpy as np
 
 # Globals
 REFERENCE_STRING_LENGTH = 30

--- a/schema/schema_template.py
+++ b/schema/schema_template.py
@@ -17,6 +17,7 @@ from sqlalchemy import Column, DateTime, Float, ForeignKey, Integer, String, Boo
 from sqlalchemy.orm import validates
 from astropy.io.votable.ucd import check_ucd
 import numpy as np
+from decimal import Decimal
 import logging
 
 # Globals
@@ -33,27 +34,9 @@ def check_string_length(value, max_length, key):
     else:
         pass
 
-def count_significant_digits_numpy(number):
-    # Convert to string with numpy and handle scientific notation
-    num_str = np.format_float_positional(number, precision=15, unique=False, fractional=False, trim='k')
 
-    # Remove leading zeros and the decimal point
-    if '.' in num_str:
-        num_str = num_str.rstrip('0').rstrip('.')
-
-    # Remove leading minus if the number is negative
-    num_str = num_str.lstrip('-')
-
-    # Split into integer and fractional parts
-    if '.' in num_str:
-        integer_part, fractional_part = num_str.split('.')
-    else:
-        integer_part, fractional_part = num_str, ''
-
-    # Count significant digits
-    significant_digits = len(integer_part.lstrip('0')) + len(fractional_part)
-
-    return significant_digits
+def count_significant_digits(numstr):
+    return len(Decimal(numstr).normalize().as_tuple().digits)
 
 
     
@@ -411,8 +394,8 @@ class Parallax(Base):
           
         if hasattr(self, 'parallax_error') and self.parallax_error is not None:
 
-            n_sig_figs_error = count_significant_digits_numpy(self.parallax_error)
-            n_sig_figs_value = count_significant_digits_numpy(value)
+            n_sig_figs_error = count_significant_digits(self.parallax_error)
+            n_sig_figs_value = count_significant_digits(value)
 
             if n_sig_figs_value > n_sig_figs_error:
                 # raise warning instead of error.

--- a/schema/schema_template.py
+++ b/schema/schema_template.py
@@ -17,10 +17,13 @@ from sqlalchemy import Column, DateTime, Float, ForeignKey, Integer, String, Boo
 from sqlalchemy.orm import validates
 from astropy.io.votable.ucd import check_ucd
 import numpy as np
+import logging
 
 # Globals
 REFERENCE_STRING_LENGTH = 30
 DESCRIPTION_STRING_LENGTH = 1000
+
+logger = logging.getLogger(__name__)
 
 # TODO: make "tabulardata" or "physicaldata" abstract classes.
 
@@ -412,7 +415,8 @@ class Parallax(Base):
             n_sig_figs_value = count_significant_digits_numpy(value)
 
             if n_sig_figs_value > n_sig_figs_error:
-                raise ValueError(f"Provided {key} is invalid; more significant figures than value: {value}")
+                # raise warning instead of error.
+                logger.warning(f"Provided {key} is invalid; more significant figures than error: {value}")
             else:
                 pass
 

--- a/schema/schema_template.py
+++ b/schema/schema_template.py
@@ -10,6 +10,7 @@ You may modify these tables, but doing so may decrease the interoperability of y
 """
 
 import enum
+import pdb
 
 from astrodbkit2.astrodb import Base
 from sqlalchemy import Column, DateTime, Float, ForeignKey, Integer, String, Boolean
@@ -50,6 +51,8 @@ def count_significant_digits_numpy(number):
     significant_digits = len(integer_part.lstrip('0')) + len(fractional_part)
 
     return significant_digits
+
+
     
 
 # -------------------------------------------------------------------------------------------------------------------
@@ -403,7 +406,8 @@ class Parallax(Base):
         if value is None:
             raise ValueError(f"Provided {key} is invalid; None: {value}")
           
-        if hasattr(self, 'parallax_error'):
+        if hasattr(self, 'parallax_error') and self.parallax_error is not None:
+
             n_sig_figs_error = count_significant_digits_numpy(self.parallax_error)
             n_sig_figs_value = count_significant_digits_numpy(value)
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -175,26 +175,6 @@ def test_coordinates(db):
     assert len(t) == 0, f"{len(t)} Sources failed coordinate checks"
 
 
-def count_significant_digits_numpy(number):
-    # Convert to string with numpy and handle scientific notation
-    num_str = np.format_float_positional(number, precision=15, unique=False, fractional=False, trim='k')
-
-    # Remove leading zeros and the decimal point
-    if '.' in num_str:
-        num_str = num_str.rstrip('0').rstrip('.')
-
-    # Remove leading minus if the number is negative
-    num_str = num_str.lstrip('-')
-
-    # Split into integer and fractional parts
-    if '.' in num_str:
-        integer_part, fractional_part = num_str.split('.')
-    else:
-        integer_part, fractional_part = num_str, ''
-
-    # Count significant digits
-    significant_digits = len(integer_part.lstrip('0')) + len(fractional_part)
-
     return significant_digits
 def test_sig_figs_parallax(db):
     # verify that the precision on parallax isn't greater than the error's precision

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -199,18 +199,10 @@ def count_significant_digits_numpy(number):
 def test_sig_figs_parallax(db):
     # verify that the precision on parallax isn't greater than the error's precision
     t = (
-        db.query(db.Parallax.c.parallax, db.Parallax.c.parallax_error)
-        .filter(
-            or_(
-                db.Parallax.c.parallax_error.is_(None),
-                db.Parallax.c.parallax_error < 0,
-                db.Parallax.c.parallax_error > 0,
-                db.Parallax.c.parallax_error < db.Parallax.c.parallax,
-            )
-        )
+        db.query(db.Parallax.c.parallax_mas, db.Parallax.c.parallax_error)
         .astropy()
     )
     for i in t:
-        parallax_sig_figs = count_significant_digits_numpy(i['parallax'])
+        parallax_sig_figs = count_significant_digits_numpy(i['parallax_mas'])
         error_sig_figs = count_significant_digits_numpy(i['parallax_error'])
         assert error_sig_figs >= parallax_sig_figs, f"Parallax error has fewer significant figures than parallax for {i['parallax']} +/- {i['parallax_error']}"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -175,7 +175,6 @@ def test_coordinates(db):
     assert len(t) == 0, f"{len(t)} Sources failed coordinate checks"
 
 
-    return significant_digits
 def test_sig_figs_parallax(db):
     # verify that the precision on parallax isn't greater than the error's precision
     t = (

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -181,7 +181,14 @@ def test_sig_figs_parallax(db):
         db.query(db.Parallax.c.parallax_mas, db.Parallax.c.parallax_error)
         .astropy()
     )
+    # create empty table to add the results to
+
+
+    wrong_sig_figs = []
     for i in t:
         parallax_sig_figs = count_significant_digits_numpy(i['parallax_mas'])
         error_sig_figs = count_significant_digits_numpy(i['parallax_error'])
-        assert error_sig_figs >= parallax_sig_figs, f"Parallax error has fewer significant figures than parallax for {i['parallax']} +/- {i['parallax_error']}"
+
+        if error_sig_figs >= parallax_sig_figs:
+            wrong_sig_figs.append(i)
+    assert len(wrong_sig_figs)==0, f"Parallax error has fewer significant figures than parallax for these sources: {wrong_sig_figs}"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -186,8 +186,8 @@ def test_sig_figs_parallax(db):
 
     wrong_sig_figs = []
     for i in t:
-        parallax_sig_figs = count_significant_digits_numpy(i['parallax_mas'])
-        error_sig_figs = count_significant_digits_numpy(i['parallax_error'])
+        parallax_sig_figs = count_significant_digits(i['parallax_mas'])
+        error_sig_figs = count_significant_digits(i['parallax_error'])
 
         if error_sig_figs >= parallax_sig_figs:
             wrong_sig_figs.append(i)


### PR DESCRIPTION
Ideally, we don't want the number of significant figures in a quantity to exceed the precision established by our error bars. This PR enforces as much for the `Parallax` table.